### PR TITLE
Load properties hierarchically

### DIFF
--- a/common-concerns/src/test/java/net/explorviz/shared/common/idgen/IdGeneratorTest.java
+++ b/common-concerns/src/test/java/net/explorviz/shared/common/idgen/IdGeneratorTest.java
@@ -6,8 +6,8 @@ import net.explorviz.shared.common.injection.CommonDependencyInjectionBinder;
 import org.glassfish.hk2.api.ServiceLocator;
 import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Tests the {@link IdGenerator}.
@@ -24,7 +24,7 @@ public class IdGeneratorTest {
   /**
    * Inject dependencies.
    */
-  @Before
+  @BeforeEach
   public void setUp() {
     final AbstractBinder binder = new CommonDependencyInjectionBinder();
     final ServiceLocator locator = ServiceLocatorUtilities.bind(binder);

--- a/config-injection/src/main/java/net/explorviz/shared/config/annotations/injection/ConfigInjectionResolver.java
+++ b/config-injection/src/main/java/net/explorviz/shared/config/annotations/injection/ConfigInjectionResolver.java
@@ -87,7 +87,7 @@ public class ConfigInjectionResolver implements InjectionResolver<Config> {
       
       Properties testProps = new Properties();
       
-      if (testProps != null) {
+      if (inputTest != null) {
         try {
           testProps.load(inputTest);
           PROP.putAll(testProps);

--- a/config-injection/src/main/java/net/explorviz/shared/config/annotations/injection/ConfigInjectionResolver.java
+++ b/config-injection/src/main/java/net/explorviz/shared/config/annotations/injection/ConfigInjectionResolver.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Singleton;
@@ -38,7 +39,7 @@ public class ConfigInjectionResolver implements InjectionResolver<Config> {
   private static final String PROPERTIES_TEST_FILENAME = "explorviz-test.properties";
 
 
-  private static final Properties PROP = new Properties();
+  private static Properties PROP = new Properties();
 
   private static Properties passedProperties = null;
 
@@ -57,43 +58,50 @@ public class ConfigInjectionResolver implements InjectionResolver<Config> {
     final ClassLoader loader = Thread.currentThread().getContextClassLoader();
 
     if (passedProperties == null) {
-
-      InputStream input = loader.getResourceAsStream(PROPERTIES_TEST_FILENAME);
-
-      if (input == null) {
-        // no testing environment, use custom or default file
-
-        input = loader.getResourceAsStream(PROPERTIES_CUSTOM_FILENAME);
-
-        if (input == null) {
-          // use default properties
-          input = loader.getResourceAsStream(PROPERTIES_DEFAULT_FILENAME);
-
-          if (input == null) {
-            LOGGER.error("Couldn't load default property file.");
-            throw this.exception;
-          }
-
-          LOGGER.info("Using default property file.");
-        } else {
-          LOGGER.info("Using custom property file.");
+      InputStream inputDefaults = loader.getResourceAsStream(PROPERTIES_DEFAULT_FILENAME);
+      InputStream inputCustom = loader.getResourceAsStream(PROPERTIES_CUSTOM_FILENAME);
+      InputStream inputTest = loader.getResourceAsStream(PROPERTIES_TEST_FILENAME);
+      
+      Properties defaultProps = new Properties();
+      
+      if (inputDefaults != null) {
+        try {
+          defaultProps.load(inputDefaults);
+          LOGGER.info("Found default properties");
+          PROP.putAll(defaultProps);
+        } catch (IOException e) {
+          LOGGER.warn("No default properties given");
         }
-      } else {
-        LOGGER.info("Using test property file.");
       }
-
-      try {
-        PROP.load(input);
-      } catch (final IOException e) {
-        LOGGER.error("Couldn't load property file.");
-        throw this.exception;
+      
+      Properties customProps = new Properties();
+      if (inputCustom != null) {
+        try {
+          customProps.load(inputCustom);
+          PROP.putAll(customProps);
+        } catch (IOException e) {
+          LOGGER.info("No custom properties");
+        }
       }
-
+      
+      
+      Properties testProps = new Properties();
+      
+      if (testProps != null) {
+        try {
+          testProps.load(inputTest);
+          PROP.putAll(testProps);
+        } catch (IOException e) {
+          LOGGER.info("No test properties");
+        }
+      }
+      
     } else {
       LOGGER.info("Using passed properties.");
       // use passed properties (e.g. for testing)
       PROP.putAll(passedProperties);
     }
+    
   }
 
   @Override

--- a/config-injection/src/main/java/net/explorviz/shared/config/annotations/injection/ConfigValuesInjectionResolver.java
+++ b/config-injection/src/main/java/net/explorviz/shared/config/annotations/injection/ConfigValuesInjectionResolver.java
@@ -37,7 +37,7 @@ public class ConfigValuesInjectionResolver implements InjectionResolver<ConfigVa
   private static final String PROPERTIES_TEST_FILENAME = "explorviz-test.properties";
 
 
-  private static final Properties PROP = new Properties();
+  private static Properties PROP = new Properties();
 
   private static Properties passedProperties = null;
 
@@ -56,38 +56,43 @@ public class ConfigValuesInjectionResolver implements InjectionResolver<ConfigVa
     final ClassLoader loader = Thread.currentThread().getContextClassLoader();
 
     if (passedProperties == null) {
-
-      InputStream input = loader.getResourceAsStream(PROPERTIES_TEST_FILENAME);
-
-      if (input == null) {
-        // no testing environment, use custom or default file
-
-        input = loader.getResourceAsStream(PROPERTIES_CUSTOM_FILENAME);
-
-        if (input == null) {
-          // use default properties
-          input = loader.getResourceAsStream(PROPERTIES_DEFAULT_FILENAME);
-
-          if (input == null) {
-            LOGGER.error("Couldn't load default property file.");
-            throw this.exception;
-          }
-
-          LOGGER.info("Using default property file.");
-        } else {
-          LOGGER.info("Using custom property file.");
+      InputStream inputDefaults = loader.getResourceAsStream(PROPERTIES_DEFAULT_FILENAME);
+      InputStream inputCustom = loader.getResourceAsStream(PROPERTIES_CUSTOM_FILENAME);
+      InputStream inputTest = loader.getResourceAsStream(PROPERTIES_TEST_FILENAME);
+      
+      Properties defaultProps = new Properties();
+      
+      if (inputDefaults != null) {
+        try {
+          defaultProps.load(inputDefaults);
+          LOGGER.info("Found default properties");
+          PROP.putAll(defaultProps);
+        } catch (IOException e) {
+          LOGGER.warn("No default properties given");
         }
-      } else {
-        LOGGER.info("Using test property file.");
       }
-
-      try {
-        PROP.load(input);
-      } catch (final IOException e) {
-        LOGGER.error("Couldn't load property file.");
-        throw this.exception;
+      
+      Properties customProps = new Properties();
+      if (inputCustom != null) {
+        try {
+          customProps.load(inputCustom);
+          PROP.putAll(customProps);
+        } catch (IOException e) {
+          LOGGER.info("No custom properties");
+        }
       }
-
+      
+      
+      Properties testProps = new Properties();
+      
+      if (testProps != null) {
+        try {
+          testProps.load(inputTest);
+          PROP.putAll(testProps);
+        } catch (IOException e) {
+          LOGGER.info("No test properties");
+        }
+      }
     } else {
       LOGGER.info("Using passed properties.");
       // use passed properties (e.g. for testing)

--- a/config-injection/src/main/java/net/explorviz/shared/config/annotations/injection/ConfigValuesInjectionResolver.java
+++ b/config-injection/src/main/java/net/explorviz/shared/config/annotations/injection/ConfigValuesInjectionResolver.java
@@ -85,7 +85,7 @@ public class ConfigValuesInjectionResolver implements InjectionResolver<ConfigVa
       
       Properties testProps = new Properties();
       
-      if (testProps != null) {
+      if (inputTest != null) {
         try {
           testProps.load(inputTest);
           PROP.putAll(testProps);


### PR DESCRIPTION
Currently, the `ConfigInjectionResolver` and `ConfigValuesInjectionResolver` searched for `explorviz-test.properties`, `explorviz-custom.properties`, and `explorviz.properties` and read the first file found.

With this PR all files are read in reverse order and keys are overridden if they existed in a prior file. E.g. if key exists in `explorviz.properties` and `explorviz-test.properties`, the value of `explorviz-test.properties` is taken. 