### PR TITLE
Only apply authorization to ExplorViz resources

### DIFF
--- a/security/src/main/java/net/explorviz/shared/security/filters/AuthorizationFilter.java
+++ b/security/src/main/java/net/explorviz/shared/security/filters/AuthorizationFilter.java
@@ -43,6 +43,12 @@ public class AuthorizationFilter implements ContainerRequestFilter {
 
   @Override
   public void filter(final ContainerRequestContext requestContext) throws IOException { // NOPMD
+    
+    // Only apply authorization to explorviz resources
+    if (!this.resourceInfo.getResourceClass().getCanonicalName().startsWith("net.explorviz")) {
+      return;
+    }
+
 
     final Method method = resourceInfo.getResourceMethod();
 
@@ -85,9 +91,11 @@ public class AuthorizationFilter implements ContainerRequestFilter {
     }
 
     // Authentication is required for non-annotated methods
+    
     if (!isAuthenticated(requestContext)) {
       throw new ForbiddenException(NOT_AUTHENTICATED_MSG);
     }
+    
   }
 
   private void performAuthorization(final String[] rolesAllowed,


### PR DESCRIPTION
Authorization is only applied to resources with (fully qualified) class names starting wit `net.explorviz`.
This, for example, is necessary to no apply authorization to the provided Swagger API resources.