### PR TITLE
Fix RolesAllowed on classes

### DIFF
--- a/security/src/main/java/net/explorviz/shared/security/filters/AuthorizationFilter.java
+++ b/security/src/main/java/net/explorviz/shared/security/filters/AuthorizationFilter.java
@@ -84,6 +84,7 @@ public class AuthorizationFilter implements ContainerRequestFilter {
     rolesAllowed = resourceInfo.getResourceClass().getAnnotation(RolesAllowed.class);
     if (rolesAllowed != null) {
       performAuthorization(rolesAllowed.value(), requestContext);
+      return;
     }
 
     // @PermitAll on the class, lowest precedence


### PR DESCRIPTION
The `@RolesAllowed` annotation at class level is broken, this PR fixes it.